### PR TITLE
fix: recalculate the range.end.character in formatting

### DIFF
--- a/lua/blink-cmp-copilot/format.lua
+++ b/lua/blink-cmp-copilot/format.lua
@@ -5,8 +5,31 @@ local trim_whitespace = function(doc)
   return string.gsub(doc, "^%s*(.-)%s*$", "%1")
 end
 
+---Get the split string
+---Ported from copilot-cmp
+---@param inputstr string
+---@param sep? string
+---@return string[]
+local function split(inputstr, sep)
+  sep = sep or inputstr:find("\r") and "\r" or "\n"
+  if sep == nil then
+    sep = "\n"
+  end
+  if not string.find(inputstr, "[\r|\n]") then
+    return { inputstr }
+  end
+  local t = {}
+  for str in string.gmatch(inputstr, "([^" .. sep .. "]+)") do
+    table.insert(t, str)
+  end
+  return t
+end
+
 ---@return blink.cmp.CompletionItem
 M.format_item = function(item, ctx, opts)
+  local splitText = split(item.text)
+  item.range["end"].character = #splitText[1]
+
   return {
     label = trim_whitespace(item.text),
     kind = vim.lsp.protocol.CompletionItemKind.Text,


### PR DESCRIPTION
In this PR, I ported the recalculation logic from `copilot-cmp` to fix the completion with unicodes.

This bug specifically manifests in Unicode environments (confirmed with Chinese & Japanese). You can observe the difference in the following video:

https://github.com/user-attachments/assets/f6930f5a-6c61-45db-bf24-1e6bcaa53649

---

### Issue Details:
The issue affects all strings containing Chinese or Japanese characters (Korean might also be affected, but untested). Here's a detailed explanation:

When I input:
```go
// 测试文字
// 测试
```

Since `测试文字` (meaning "test words") is already in the first line, Copilot should fill the second line with the same characters, resulting in:

```go
// 测试文字
// 测试文字
```

However, the actual result was:

```go
// 测试文字
// 测试文字<8b>试
```

### Root Cause:
Both `blink.cmp` and `nvim-cmp` use the same function [`vim.lsp.util.apply_text_edits`](https://github.com/Saghen/blink.cmp/blob/37dbb7325c2917e32cbdf02fd598389be4fcc8b0/lua/blink/cmp/lib/text_edits.lua#L10-L10) for text insertion. While `copilot-cmp` handles this correctly, I investigated the differences in arguments between `copilot-cmp` and `blink-cmp-copilot`. I discovered that `copilot-cmp` has its own handling for range end characters ([link](https://github.com/zbirenbaum/copilot-cmp/blob/15fc12af3d0109fa76b60b5cffa1373697e261d1/lua/copilot_cmp/format.lua#L116)).

In Copilot's response, the `range.end.character` is `5` (length of `// 测试`, where each Chinese character counts as 1, not 3 as in Lua 5.1 string standard). However, according to [Microsoft's LSP Docs](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit), which Neovim's API `vim.lsp.util.apply_text_edits` follows, the range should include all manipulated parts.

### Solution:
This PR ports `nvim-cmp`'s solution to `blink-cmp-copilot`, and it now works perfectly on my Mac.